### PR TITLE
Add Interrupt vector definitions

### DIFF
--- a/hardware.inc
+++ b/hardware.inc
@@ -36,6 +36,7 @@
 ;* Rev 4.7.1 - 05-Jul-22 : Added RPB_LED_ON constant
 ;* Rev 4.8.0 - 25-Oct-22 : Changed background addressing constants (zlago)
 ;* Rev 4.8.1 - 29-Apr-23 : Added rOPRI (rbong)
+;* Rev 4.9.0 - 24-Jun-23 : Added definitions for interrupt vectors (sukus)
 
 
 ; NOTE: REVISION NUMBER CHANGES MUST BE REFLECTED
@@ -55,7 +56,7 @@ DEF HARDWARE_INC EQU 1
 ;           rev_Check_hardware_inc 4.1 (equivalent to 4.1.0)
 ;           rev_Check_hardware_inc 4 (equivalent to 4.0.0)
 MACRO rev_Check_hardware_inc
-    DEF CUR_VER equs "4,8,1"    ; ** UPDATE THIS LINE WHEN CHANGING THE REVISION NUMBER **
+    DEF CUR_VER equs "4,9,0"    ; ** UPDATE THIS LINE WHEN CHANGING THE REVISION NUMBER **
 
     DEF MIN_VER equs STRRPL("\1", ".", ",")
     DEF INTERNAL_CHK equs """MACRO ___internal
@@ -913,6 +914,19 @@ DEF BOOTUP_A_MGB    EQU $FF ; Mini GameBoy (Pocket GameBoy)
 ; other system running in GBC mode
 DEF BOOTUP_B_CGB    EQU %00000000
 DEF BOOTUP_B_AGB    EQU %00000001   ; GBA, GBA SP, Game Boy Player, or New GBA SP
+
+
+;***************************************************************************
+;*
+;* Interrupt vector addresses
+;*
+;***************************************************************************
+
+DEF INT_HANDLER_VBLANK EQU $0040
+DEF INT_HANDLER_STAT   EQU $0048
+DEF INT_HANDLER_TIMER  EQU $0050
+DEF INT_HANDLER_SERIAL EQU $0058
+DEF INT_HANDLER_JOYPAD EQU $0060
 
 
 ;***************************************************************************


### PR DESCRIPTION
These addresses are hardware related, and we didn't have existing definitions for them. I am not completely sure about the names I gave them, any input is welcomed!